### PR TITLE
Rename RegisterRenderTrigger to avoid unintended overlaod matching.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Set common properties regarding assembly information and nuget packages -->
   <PropertyGroup>
-    <TimeWarpStateVersion>11.0.0-beta.71+8.0.303</TimeWarpStateVersion>
+    <TimeWarpStateVersion>11.0.0-beta.72+8.0.303</TimeWarpStateVersion>
     <Authors>Steven T. Cramer</Authors>
     <Product>TimeWarp State</Product>
     <PackageVersion>$(TimeWarpStateVersion)</PackageVersion>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="Fixie.TestAdapter" Version="3.4.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageVersion Include="MediatR" Version="12.3.0" />
+    <PackageVersion Include="MediatR" Version="12.4.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.7" />
@@ -36,7 +36,7 @@
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.19.1" />
-    <PackageVersion Include="Microsoft.Playwright.MSTest" Version="1.45.0" />
+    <PackageVersion Include="Microsoft.Playwright.MSTest" Version="1.45.1" />
     <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.44.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.5.3" />

--- a/Source/TimeWarp.State/Components/TimeWarpStateComponent.RegisterRenderTrigger.cs
+++ b/Source/TimeWarp.State/Components/TimeWarpStateComponent.RegisterRenderTrigger.cs
@@ -4,7 +4,7 @@ public partial class TimeWarpStateComponent
 {
   private readonly ConcurrentDictionary<Type, Func<bool>> RenderTriggers = new();
   private readonly ConcurrentDictionary<(Type StateType, string PropertyName), Func<object, object, bool>> CompiledPropertyComparisons = new();
-  
+
   /// <summary>
   /// Set this to true if something in the component has changed that requires a re-render.
   /// </summary>
@@ -31,7 +31,7 @@ public partial class TimeWarpStateComponent
     NeedsRerender = RenderTriggers.TryGetValue(stateType, out Func<bool>? check) && check();
     return NeedsRerender;
   }
-  
+
   /// <summary>
   /// Determines whether the component should re-render based on changes in a specific state type.
   /// </summary>
@@ -77,9 +77,9 @@ public partial class TimeWarpStateComponent
   protected void RegisterRenderTrigger<T>(Expression<Func<T, object?>> propertySelector) where T : class
   {
     ArgumentNullException.ThrowIfNull(propertySelector);
-    
+
     Func<T, T, bool> comparisonFunc = CreateComparisonFunc(propertySelector);
-    
+
     RenderTriggers[typeof(T)] = () =>
     {
       T? previousState = GetPreviousState<T>();
@@ -91,12 +91,12 @@ public partial class TimeWarpStateComponent
   private static Func<T, T, bool> CreateComparisonFunc<T>(Expression<Func<T, object?>> propertySelector) where T : class
   {
     Func<T, object?> compiledSelector = propertySelector.Compile();
-    
+
     return (T previous, T current) =>
     {
       object? previousValue = compiledSelector(previous);
       object? currentValue = compiledSelector(current);
-        
+
       return !Equals(previousValue, currentValue);
     };
   }

--- a/Source/TimeWarp.State/Components/TimeWarpStateComponent.RegisterRenderTrigger.cs
+++ b/Source/TimeWarp.State/Components/TimeWarpStateComponent.RegisterRenderTrigger.cs
@@ -2,6 +2,26 @@ namespace TimeWarp.State;
 
 public partial class TimeWarpStateComponent
 {
+  /// <summary>
+  /// Registers a render trigger for a specific state type.
+  /// </summary>
+  /// <typeparam name="T">The type of state to check. Must be a reference type.</typeparam>
+  /// <param name="triggerCondition">A function that takes the previous state of type T and returns a boolean indicating whether a re-render is needed.</param>
+  /// <remarks>
+  /// This method adds a new entry to the RenderTriggers dictionary. The key is the Type of T, 
+  /// and the value is a function that will be called to determine if a re-render is necessary 
+  /// when the state of type T changes. The function should compare the previous state 
+  /// (passed as an argument) with the current state (which should be accessible within the component).
+  /// </remarks>
+  /// <example>
+  /// <code>
+  /// RegisterRenderTrigger&lt;UserState&gt;(previousUserState => UserState.Name != previousUserState.Name);
+  /// </code>
+  /// </example>
+  protected void RegisterRenderTriggerCondition<T>(Func<T, bool> triggerCondition) where T : class
+  {
+    RenderTriggers[typeof(T)] = () => ShouldReRender(typeof(T), triggerCondition);
+  }
   protected void RegisterRenderTrigger<T>(Expression<Func<T, object?>> propertySelector) where T : class
   {
     ArgumentNullException.ThrowIfNull(propertySelector);
@@ -16,7 +36,7 @@ public partial class TimeWarpStateComponent
     };
   }
 
-  private Func<T, T, bool> CreateComparisonFunc<T>(Expression<Func<T, object?>> propertySelector) where T : class
+  private static Func<T, T, bool> CreateComparisonFunc<T>(Expression<Func<T, object?>> propertySelector) where T : class
   {
     Func<T, object?> compiledSelector = propertySelector.Compile();
     

--- a/Source/TimeWarp.State/Components/TimeWarpStateComponent.RegisterRenderTrigger.cs
+++ b/Source/TimeWarp.State/Components/TimeWarpStateComponent.RegisterRenderTrigger.cs
@@ -3,6 +3,8 @@ namespace TimeWarp.State;
 public partial class TimeWarpStateComponent
 {
   private readonly ConcurrentDictionary<Type, Func<bool>> RenderTriggers = new();
+
+  private T? GetPreviousState<T>() => Store.GetPreviousState<T>();
   private readonly ConcurrentDictionary<(Type StateType, string PropertyName), Func<object, object, bool>> CompiledPropertyComparisons = new();
 
   /// <summary>

--- a/Source/TimeWarp.State/Components/TimeWarpStateComponent.RegisterRenderTrigger.cs
+++ b/Source/TimeWarp.State/Components/TimeWarpStateComponent.RegisterRenderTrigger.cs
@@ -1,0 +1,76 @@
+namespace TimeWarp.State;
+
+public partial class TimeWarpStateComponent
+{
+  protected void RegisterRenderTrigger<T>(Expression<Func<T, object?>> propertySelector) where T : class
+  {
+    ArgumentNullException.ThrowIfNull(propertySelector);
+    
+    Func<T, T, bool> comparisonFunc = CreateComparisonFunc(propertySelector);
+    
+    RenderTriggers[typeof(T)] = () =>
+    {
+      T? previousState = GetPreviousState<T>();
+      T currentState = GetState<T>(false);
+      return previousState == null || comparisonFunc(previousState, currentState);
+    };
+  }
+
+  private Func<T, T, bool> CreateComparisonFunc<T>(Expression<Func<T, object?>> propertySelector) where T : class
+  {
+    Func<T, object?> compiledSelector = propertySelector.Compile();
+    
+    return (T previous, T current) =>
+    {
+      object? previousValue = compiledSelector(previous);
+      object? currentValue = compiledSelector(current);
+        
+      return !Equals(previousValue, currentValue);
+    };
+  }
+
+  private string GetPropertyPath<T>(Expression<Func<T, object?>> propertySelector)
+  {
+    if (propertySelector.Body is MemberExpression memberExpression)
+    {
+      return GetMemberExpressionPath(memberExpression);
+    }
+    else if (propertySelector.Body is UnaryExpression unaryExpression)
+    {
+      if (unaryExpression.Operand is MemberExpression memberExpr)
+      {
+        return GetMemberExpressionPath(memberExpr);
+      }
+    }
+    throw new ArgumentException("Invalid property selector", nameof(propertySelector));
+  }
+
+// ... other methods remain the same
+  private string GetMemberExpressionPath(MemberExpression? expression)
+  {
+    var path = new List<string>();
+    while (expression != null)
+    {
+      path.Add(expression.Member.Name);
+      expression = expression.Expression as MemberExpression;
+    }
+    path.Reverse();
+    return string.Join(".", path);
+  }
+
+  private object? GetPropertyValue(object? obj, string propertyPath)// Add '?' to 'object?'
+  {
+    if (obj == null) return null;// Add null check at the beginning
+
+    string[] properties = propertyPath.Split('.');
+    object? value = obj;
+    foreach (string property in properties)
+    {
+      if (value == null) return null;
+      PropertyInfo? propertyInfo = value.GetType().GetProperty(property);
+      if (propertyInfo == null) return null;
+      value = propertyInfo.GetValue(value);
+    }
+    return value;
+  }
+}

--- a/Source/TimeWarp.State/Components/TimeWarpStateComponent.RegisterRenderTrigger.cs
+++ b/Source/TimeWarp.State/Components/TimeWarpStateComponent.RegisterRenderTrigger.cs
@@ -100,49 +100,4 @@ public partial class TimeWarpStateComponent
       return !Equals(previousValue, currentValue);
     };
   }
-
-  private string GetPropertyPath<T>(Expression<Func<T, object?>> propertySelector)
-  {
-    if (propertySelector.Body is MemberExpression memberExpression)
-    {
-      return GetMemberExpressionPath(memberExpression);
-    }
-    else if (propertySelector.Body is UnaryExpression unaryExpression)
-    {
-      if (unaryExpression.Operand is MemberExpression memberExpr)
-      {
-        return GetMemberExpressionPath(memberExpr);
-      }
-    }
-    throw new ArgumentException("Invalid property selector", nameof(propertySelector));
-  }
-
-// ... other methods remain the same
-  private string GetMemberExpressionPath(MemberExpression? expression)
-  {
-    var path = new List<string>();
-    while (expression != null)
-    {
-      path.Add(expression.Member.Name);
-      expression = expression.Expression as MemberExpression;
-    }
-    path.Reverse();
-    return string.Join(".", path);
-  }
-
-  private object? GetPropertyValue(object? obj, string propertyPath)// Add '?' to 'object?'
-  {
-    if (obj == null) return null;// Add null check at the beginning
-
-    string[] properties = propertyPath.Split('.');
-    object? value = obj;
-    foreach (string property in properties)
-    {
-      if (value == null) return null;
-      PropertyInfo? propertyInfo = value.GetType().GetProperty(property);
-      if (propertyInfo == null) return null;
-      value = propertyInfo.GetValue(value);
-    }
-    return value;
-  }
 }

--- a/Source/TimeWarp.State/Components/TimeWarpStateComponent.RegisterRenderTrigger.cs
+++ b/Source/TimeWarp.State/Components/TimeWarpStateComponent.RegisterRenderTrigger.cs
@@ -2,6 +2,58 @@ namespace TimeWarp.State;
 
 public partial class TimeWarpStateComponent
 {
+  private readonly ConcurrentDictionary<Type, Func<bool>> RenderTriggers = new();
+  private readonly ConcurrentDictionary<(Type StateType, string PropertyName), Func<object, object, bool>> CompiledPropertyComparisons = new();
+  
+  /// <summary>
+  /// Set this to true if something in the component has changed that requires a re-render.
+  /// </summary>
+  protected bool NeedsRerender;
+
+  /// <inheritdoc />
+  protected override bool ShouldRender()
+  {
+    // If there are no RenderTriggers, default to true (standard Blazor behavior)
+    if (RenderTriggers.Count == 0)
+      return true;
+
+    // If there are RenderTriggers, use NeedsRerender flag
+    bool result = NeedsRerender;
+    NeedsRerender = false;
+    return result;
+  }
+
+  /// <inheritdoc />
+  public virtual bool ShouldReRender(Type stateType)
+  {
+    ArgumentNullException.ThrowIfNull(stateType);
+
+    NeedsRerender = RenderTriggers.TryGetValue(stateType, out Func<bool>? check) && check();
+    return NeedsRerender;
+  }
+  
+  /// <summary>
+  /// Determines whether the component should re-render based on changes in a specific state type.
+  /// </summary>
+  /// <typeparam name="T">The type of state to check.</typeparam>
+  /// <param name="stateType">The type of state that has changed.</param>
+  /// <param name="condition">A function that evaluates given the previous state and returns true if a re-render is needed.</param>
+  /// <returns>True if the component should re-render; otherwise, false.</returns>
+  /// <remarks>
+  /// This method checks if the changed state type matches the generic type parameter T.
+  /// If it matches, it retrieves the previous state and applies the provided condition.
+  /// The component will re-render if the condition returns true given the previous state.
+  /// </remarks>
+  protected bool ShouldReRender<T>(Type stateType, Func<T, bool> condition) where T : class
+  {
+    if (stateType != typeof(T)) return false;
+    T? previousState = GetPreviousState<T>();
+    if (previousState == null) return true;
+    bool result = condition(previousState);
+    Logger.LogDebug(EventIds.TimeWarpStateComponent_ShouldReRender, "ShouldReRender ComponentType: {ComponentId} StateType: {StateType} Result: {Result}", Id, stateType.FullName, result);
+
+    return result;
+  }
   /// <summary>
   /// Registers a render trigger for a specific state type.
   /// </summary>

--- a/Source/TimeWarp.State/Components/TimeWarpStateComponent.RenderMode.cs
+++ b/Source/TimeWarp.State/Components/TimeWarpStateComponent.RenderMode.cs
@@ -1,0 +1,66 @@
+namespace TimeWarp.State;
+
+public partial class TimeWarpStateComponent
+{
+  private static readonly ConcurrentDictionary<Type, string> ConfiguredRenderModeCache = new();
+  private static readonly ConcurrentDictionary<Type, bool> TypeRenderAttributeCache = new();
+
+  private bool UsesRenderMode;
+  private bool HasRendered;
+
+  protected string ConfiguredRenderMode =>
+    ConfiguredRenderModeCache.GetOrAdd(this.GetType(), type =>
+    {
+      // Use reflection to get all attributes on the current component type.
+      object[] attributes = type.GetCustomAttributes(true);
+
+      foreach (object attribute in attributes)
+      {
+        // Check if the type name of the attribute contains the expected name.
+        Type attributeType = attribute.GetType();
+        if (attributeType.Name.Contains("PrivateComponentRenderModeAttribute"))
+        {
+          // Try to get the 'Mode' property value of the attribute.
+          PropertyInfo? modeProperty = attributeType.GetProperty("Mode");
+          if (modeProperty != null)
+          {
+            // Use dynamic to bypass compile-time type checking
+            dynamic? modeValue = modeProperty.GetValue(attribute);
+            // Return the type name of the Mode property's value.
+            return modeValue == null ? "None" : modeValue.GetType().Name;
+          }
+        }
+      }
+
+      // If no matching attribute is found, return a default identifier.
+      return "None";// Adjust as needed for your default case.
+    });
+
+  /// <summary>
+  ///   Indicates if the component is being prerendered.
+  /// </summary>
+  protected bool IsPreRendering => GetCurrentRenderMode() == State.CurrentRenderMode.PreRendering;
+  protected string CurrentRenderMode => GetCurrentRenderMode().ToString();
+
+  private CurrentRenderMode GetCurrentRenderMode()
+  {
+    UsesRenderMode = true;
+    if (OperatingSystem.IsBrowser()) return State.CurrentRenderMode.Wasm;
+
+    if (HasRendered) return State.CurrentRenderMode.Server;
+
+    bool hasRenderAttribute = TypeRenderAttributeCache.GetOrAdd(this.GetType(), type =>
+      type.GetCustomAttributes(true)
+        .Any(attr => attr.GetType().Name.Contains("PrivateComponentRenderModeAttribute")));
+
+    return hasRenderAttribute ? State.CurrentRenderMode.PreRendering : State.CurrentRenderMode.Static;
+  }
+}
+
+public enum CurrentRenderMode
+{
+  Static,
+  PreRendering,
+  Server,
+  Wasm,
+}

--- a/Source/TimeWarp.State/Components/TimeWarpStateComponent.cs
+++ b/Source/TimeWarp.State/Components/TimeWarpStateComponent.cs
@@ -18,7 +18,6 @@ public partial class TimeWarpStateComponent : ComponentBase, IDisposable, ITimeW
   [Inject] protected IMediator Mediator { get; set; } = null!;
 
   private static readonly ConcurrentDictionary<string, int> InstanceCounts = new();
-  private static readonly ConcurrentDictionary<string, int> RenderCounts = new();
   /// <summary>
   ///   A generated unique Id based on the Class name and number of times they have been created
   /// </summary>
@@ -28,8 +27,6 @@ public partial class TimeWarpStateComponent : ComponentBase, IDisposable, ITimeW
   ///   Allows for the Assigning of a value one can use to select an element during automated testing.
   /// </summary>
   [Parameter] public string? TestId { get; set; }
-
-  public int RenderCount => RenderCounts.GetValueOrDefault(Id, 0);
 
   public TimeWarpStateComponent()
   {
@@ -41,20 +38,6 @@ public partial class TimeWarpStateComponent : ComponentBase, IDisposable, ITimeW
   protected override void OnInitialized()
   {
     Logger.LogDebug(EventIds.TimeWarpStateComponent_Constructed, "TimeWarpStateComponent created: {Id}", Id);
-  }
-
-  protected override void OnAfterRender(bool firstRender)
-  {
-    base.OnAfterRender(firstRender);
-    IncrementRenderCount();
-    int renderCount = RenderCounts[Id];
-    Logger.LogTrace(EventIds.TimeWarpStateComponent_RenderCount, "{Id}: Rendered, RenderCount: {RenderCount}", Id, renderCount);
-    if (!firstRender) return;
-    HasRendered = true;
-    if (UsesRenderMode)
-    {
-      StateHasChanged();
-    }
   }
 
   public virtual void Dispose()
@@ -83,9 +66,4 @@ public partial class TimeWarpStateComponent : ComponentBase, IDisposable, ITimeW
   ///   Exposes StateHasChanged
   /// </summary>
   public void ReRender() => InvokeAsync(StateHasChanged);
-
-  private void IncrementRenderCount()
-  {
-    RenderCounts.AddOrUpdate(Id, 1, (_, count) => count + 1);
-  }
 }

--- a/Source/TimeWarp.State/Components/TimeWarpStateComponent.cs
+++ b/Source/TimeWarp.State/Components/TimeWarpStateComponent.cs
@@ -19,9 +19,6 @@ public partial class TimeWarpStateComponent : ComponentBase, IDisposable, ITimeW
 
   private static readonly ConcurrentDictionary<string, int> InstanceCounts = new();
   private static readonly ConcurrentDictionary<string, int> RenderCounts = new();
-  private static readonly ConcurrentDictionary<Type, string> ConfiguredRenderModeCache = new();
-  private static readonly ConcurrentDictionary<Type, bool> TypeRenderAttributeCache = new();
-
   /// <summary>
   ///   A generated unique Id based on the Class name and number of times they have been created
   /// </summary>
@@ -39,42 +36,7 @@ public partial class TimeWarpStateComponent : ComponentBase, IDisposable, ITimeW
   /// Set this to true if something in the component has changed that requires a re-render.
   /// </summary>
   protected bool NeedsRerender;
-  private bool HasRendered;
-  private bool UsesRenderMode;
   
-  protected string ConfiguredRenderMode =>
-    ConfiguredRenderModeCache.GetOrAdd(this.GetType(), type =>
-    {
-      // Use reflection to get all attributes on the current component type.
-      object[] attributes = type.GetCustomAttributes(true);
-
-      foreach (object attribute in attributes)
-      {
-        // Check if the type name of the attribute contains the expected name.
-        Type attributeType = attribute.GetType();
-        if (attributeType.Name.Contains("PrivateComponentRenderModeAttribute"))
-        {
-          // Try to get the 'Mode' property value of the attribute.
-          PropertyInfo? modeProperty = attributeType.GetProperty("Mode");
-          if (modeProperty != null)
-          {
-            // Use dynamic to bypass compile-time type checking
-            dynamic? modeValue = modeProperty.GetValue(attribute);
-            // Return the type name of the Mode property's value.
-            return modeValue == null ? "None" : modeValue.GetType().Name;
-          }
-        }
-      }
-
-      // If no matching attribute is found, return a default identifier.
-      return "None";// Adjust as needed for your default case.
-    });
-
-  /// <summary>
-  ///   Indicates if the component is being prerendered.
-  /// </summary>
-  protected bool IsPreRendering => GetCurrentRenderMode() == State.CurrentRenderMode.PreRendering;
-  protected string CurrentRenderMode => GetCurrentRenderMode().ToString();
   public int RenderCount => RenderCounts.GetValueOrDefault(Id, 0);
   
   public TimeWarpStateComponent()
@@ -172,21 +134,6 @@ public partial class TimeWarpStateComponent : ComponentBase, IDisposable, ITimeW
   
   private T? GetPreviousState<T>() => Store.GetPreviousState<T>();
   
-  private CurrentRenderMode GetCurrentRenderMode()
-  {
-    UsesRenderMode = true;
-    if (OperatingSystem.IsBrowser()) return State.CurrentRenderMode.Wasm;
-
-    if (HasRendered) return State.CurrentRenderMode.Server;
-
-    bool hasRenderAttribute = TypeRenderAttributeCache.GetOrAdd(this.GetType(), type =>
-      type.GetCustomAttributes(true)
-        .Any(attr => attr.GetType().Name.Contains("PrivateComponentRenderModeAttribute")));
-
-    return hasRenderAttribute ? State.CurrentRenderMode.PreRendering : State.CurrentRenderMode.Static;
-  }
-
-
   /// <summary>
   ///   Exposes StateHasChanged
   /// </summary>
@@ -196,12 +143,4 @@ public partial class TimeWarpStateComponent : ComponentBase, IDisposable, ITimeW
   {
     RenderCounts.AddOrUpdate(Id, 1, (_, count) => count + 1);
   }
-}
-
-public enum CurrentRenderMode
-{
-  Static,
-  PreRendering,
-  Server,
-  Wasm,
 }

--- a/Source/TimeWarp.State/Components/TimeWarpStateComponent.cs
+++ b/Source/TimeWarp.State/Components/TimeWarpStateComponent.cs
@@ -157,27 +157,6 @@ public partial class TimeWarpStateComponent : ComponentBase, IDisposable, ITimeW
   }
   
   /// <summary>
-  /// Registers a render trigger for a specific state type.
-  /// </summary>
-  /// <typeparam name="T">The type of state to check. Must be a reference type.</typeparam>
-  /// <param name="triggerCondition">A function that takes the previous state of type T and returns a boolean indicating whether a re-render is needed.</param>
-  /// <remarks>
-  /// This method adds a new entry to the RenderTriggers dictionary. The key is the Type of T, 
-  /// and the value is a function that will be called to determine if a re-render is necessary 
-  /// when the state of type T changes. The function should compare the previous state 
-  /// (passed as an argument) with the current state (which should be accessible within the component).
-  /// </remarks>
-  /// <example>
-  /// <code>
-  /// RegisterRenderTrigger&lt;UserState&gt;(previousUserState => UserState.Name != previousUserState.Name);
-  /// </code>
-  /// </example>
-  protected void RegisterRenderTrigger<T>(Func<T, bool> triggerCondition) where T : class
-  {
-    RenderTriggers[typeof(T)] = () => ShouldReRender(typeof(T), triggerCondition);
-  }
-  
-  /// <summary>
   ///   Place a Subscription for the calling component
   ///   And returns the requested state 
   /// </summary>

--- a/Source/TimeWarp.State/Components/TimeWarpStateComponent.cs
+++ b/Source/TimeWarp.State/Components/TimeWarpStateComponent.cs
@@ -79,8 +79,6 @@ public partial class TimeWarpStateComponent : ComponentBase, IDisposable, ITimeW
     return Store.GetState<T>();
   }
 
-  private T? GetPreviousState<T>() => Store.GetPreviousState<T>();
-
   /// <summary>
   ///   Exposes StateHasChanged
   /// </summary>

--- a/Source/TimeWarp.State/Components/TimeWarpStateComponent.cs
+++ b/Source/TimeWarp.State/Components/TimeWarpStateComponent.cs
@@ -9,7 +9,7 @@ public partial class TimeWarpStateComponent : ComponentBase, IDisposable, ITimeW
 {
   [Inject] private IStore Store { get; set; } = null!;
   [Inject] private ILogger<TimeWarpStateComponent> Logger { get; set; } = null!;
-  
+
   /// <summary>
   ///   Maintains all components that subscribe to a State.
   ///   Is updated by using the GetState method
@@ -23,26 +23,26 @@ public partial class TimeWarpStateComponent : ComponentBase, IDisposable, ITimeW
   ///   A generated unique Id based on the Class name and number of times they have been created
   /// </summary>
   public string Id { get; }
-  
+
   /// <summary>
   ///   Allows for the Assigning of a value one can use to select an element during automated testing.
   /// </summary>
   [Parameter] public string? TestId { get; set; }
-  
+
   public int RenderCount => RenderCounts.GetValueOrDefault(Id, 0);
-  
+
   public TimeWarpStateComponent()
   {
     string name = GetType().Name;
     int count = InstanceCounts.AddOrUpdate(name, 1, updateValueFactory: (_, value) => value + 1);
     Id = $"{name}-{count}";
   }
-  
+
   protected override void OnInitialized()
   {
-    Logger.LogDebug(EventIds.TimeWarpStateComponent_Constructed,"TimeWarpStateComponent created: {Id}", Id);    
+    Logger.LogDebug(EventIds.TimeWarpStateComponent_Constructed, "TimeWarpStateComponent created: {Id}", Id);
   }
-  
+
   protected override void OnAfterRender(bool firstRender)
   {
     base.OnAfterRender(firstRender);
@@ -56,7 +56,7 @@ public partial class TimeWarpStateComponent : ComponentBase, IDisposable, ITimeW
       StateHasChanged();
     }
   }
-  
+
   public virtual void Dispose()
   {
     Logger.LogDebug(EventIds.TimeWarpStateComponent_Disposing, "{Id}: Disposing, removing subscriptions. Total renders: {RenderCount}", Id, RenderCount);
@@ -64,7 +64,7 @@ public partial class TimeWarpStateComponent : ComponentBase, IDisposable, ITimeW
     RenderCounts.TryRemove(Id, out _);
     GC.SuppressFinalize(this);
   }
-  
+
   /// <summary>
   ///   Place a Subscription for the calling component
   ///   And returns the requested state 
@@ -78,14 +78,14 @@ public partial class TimeWarpStateComponent : ComponentBase, IDisposable, ITimeW
     if (placeSubscription) Subscriptions.Add(stateType, this);
     return Store.GetState<T>();
   }
-  
+
   private T? GetPreviousState<T>() => Store.GetPreviousState<T>();
-  
+
   /// <summary>
   ///   Exposes StateHasChanged
   /// </summary>
   public void ReRender() => InvokeAsync(StateHasChanged);
-  
+
   private void IncrementRenderCount()
   {
     RenderCounts.AddOrUpdate(Id, 1, (_, count) => count + 1);

--- a/Tests/Test.App/Test.App.Client/Features/Counter/Components/Counter.razor
+++ b/Tests/Test.App/Test.App.Client/Features/Counter/Components/Counter.razor
@@ -5,7 +5,7 @@
 {
   protected override void OnInitialized()
   {
-    // RegisterRenderTrigger<CounterState>(p => p.Count != CounterState.Count);
+    //RegisterRenderTrigger<CounterState>(p => p.Count != CounterState.Count);
     RegisterRenderTrigger<CounterState>(p => p.Count);
     base.OnInitialized();
   }

--- a/Tests/TimeWarp.State.Tests/ConventionTests.cs
+++ b/Tests/TimeWarp.State.Tests/ConventionTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace ConventionTest_;
 
-using FluentAssertions;
 using TimeWarp.Fixie;
 
 [TestTag(TestTags.Fast)]

--- a/Tests/TimeWarp.State.Tests/GlobalUsings.cs
+++ b/Tests/TimeWarp.State.Tests/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using FluentAssertions;
+global using System.Linq.Expressions;

--- a/Tests/TimeWarp.State.Tests/GlobalUsings.cs
+++ b/Tests/TimeWarp.State.Tests/GlobalUsings.cs
@@ -1,2 +1,5 @@
 global using FluentAssertions;
+global using MediatR;
 global using System.Linq.Expressions;
+global using System.Reflection;
+global using TimeWarp.State;

--- a/Tests/TimeWarp.State.Tests/TimeWarpStateComponent/RegisterRenderTriggerTests.cs
+++ b/Tests/TimeWarp.State.Tests/TimeWarpStateComponent/RegisterRenderTriggerTests.cs
@@ -1,0 +1,76 @@
+namespace RegisterRenderTrigger;
+
+public class Should_ 
+{
+  public static void Register_RenderTrigger_With_Valid_PropertySelector()
+  {
+    TestComponent sut = new();
+    TestStore store = new();
+    
+    // Use reflection to set the private Store property
+    PropertyInfo? storeProperty = typeof(TimeWarpStateComponent).GetProperty("Store", BindingFlags.NonPublic | BindingFlags.Instance);
+    storeProperty?.SetValue(sut, store);
+    
+    TestClass testInstance = new() { SomeProperty = "Initial" };
+    store.SetState(testInstance); // Previous state will be null
+    Expression<Func<TestClass, object?>> propertySelector = t => t.SomeProperty;
+
+    // Act
+    sut.RegisterRenderTrigger(propertySelector);
+
+    // Assert
+    sut.Should().NotBeNull();
+    sut.ShouldReRender(typeof(TestClass)).Should().BeTrue(); // Because PreviousState is null
+    store.SetState(testInstance); // Set the state to the same value so previous state will be the same
+    sut.ShouldReRender(typeof(TestClass)).Should().BeFalse(); // Because the state has not changed
+  }
+
+  public static void RegisterRenderTrigger_NullPropertySelector_ThrowsArgumentNullException()
+  {
+    // Arrange
+    TestComponent sut = new();
+    Expression<Func<object, object?>> propertySelector = null!;
+
+    // Act and Assert
+    sut.Invoking(c => c.RegisterRenderTrigger(propertySelector))
+      .Should().Throw<ArgumentNullException>();
+  }
+  
+  private class TestClass:IState
+  {
+    public string? SomeProperty { get; set; }
+    public int AnotherProperty { get; set; }
+    // properties below are not used by the tests
+    public ISender Sender { get; set; } = null!;
+    public Guid Guid { get; } = Guid.Empty; 
+    public void Initialize() => throw new NotImplementedException();
+  }
+}
+
+public class TestComponent : TimeWarpStateComponent
+{
+  public new void RegisterRenderTrigger<T>(Expression<Func<T, object?>> propertySelector) where T : class
+  {
+    base.RegisterRenderTrigger(propertySelector);
+  }
+}
+
+public class TestStore : IStore
+{
+  private IState State { get; set; } = null!;
+  private IState PreviousState { get; set; } = null!;
+  
+  public object GetState(Type stateType) => State;
+  public TState GetState<TState>() => (TState)State;
+  public void SetState(IState newState)
+  {
+    PreviousState = State;
+    State = newState;
+  }
+  public TState? GetPreviousState<TState>() => (TState?)PreviousState;
+  
+  // Properties below are not used by the tests
+  public Guid Guid { get; } = Guid.Empty;
+  public SemaphoreSlim GetSemaphore(Type stateType) => throw new NotImplementedException();
+  public void Reset() => throw new NotImplementedException();
+}

--- a/Tests/TimeWarp.State.Tests/TimeWarpStateComponent/RegisterRenderTriggerTests.cs
+++ b/Tests/TimeWarp.State.Tests/TimeWarpStateComponent/RegisterRenderTriggerTests.cs
@@ -1,52 +1,108 @@
 namespace RegisterRenderTrigger;
 
+using TimeWarp.Fixie;
+
 public class Should_ 
 {
-  public static void Register_RenderTrigger_With_Valid_PropertySelector()
+  public static void Register_RenderTrigger_With_NullableString_PropertySelector()
   {
     TestComponent sut = new();
     TestStore store = new();
     
     // Use reflection to set the private Store property
-    PropertyInfo? storeProperty = typeof(TimeWarpStateComponent).GetProperty("Store", BindingFlags.NonPublic | BindingFlags.Instance);
-    storeProperty?.SetValue(sut, store);
+    store.SetComponentStore(sut);
+    // Make three states to test with
     
-    TestClass testInstance = new() { SomeProperty = "Initial" };
-    store.SetState(testInstance); // Previous state will be null
-    Expression<Func<TestClass, object?>> propertySelector = t => t.SomeProperty;
+    TestState state0 = new() { NullableStringProperty = "Initial" };
+    TestState state1 = new() { NullableStringProperty = "Changed" };
+    TestState state2 = new() { NullableStringProperty = "Changed", AnotherProperty = "Changed some other property" };
+    
+    store.SetState(state0); // Previous state will be null
+    Expression<Func<TestState, object?>> propertySelector = t => t.NullableStringProperty;
 
     // Act
     sut.RegisterRenderTrigger(propertySelector);
 
     // Assert
     sut.Should().NotBeNull();
-    sut.ShouldReRender(typeof(TestClass)).Should().BeTrue(); // Because PreviousState is null
-    store.SetState(testInstance); // Set the state to the same value so previous state will be the same
-    sut.ShouldReRender(typeof(TestClass)).Should().BeFalse(); // Because the state has not changed
-  }
-
-  public static void RegisterRenderTrigger_NullPropertySelector_ThrowsArgumentNullException()
-  {
-    // Arrange
-    TestComponent sut = new();
-    Expression<Func<object, object?>> propertySelector = null!;
-
-    // Act and Assert
-    sut.Invoking(c => c.RegisterRenderTrigger(propertySelector))
-      .Should().Throw<ArgumentNullException>();
+    sut.ShouldReRender(typeof(TestState)).Should().BeTrue(); // Because PreviousState is null
+    store.SetState(state1); 
+    sut.ShouldReRender(typeof(TestState)).Should().BeTrue(); // Because the property we are watching has changed
+    store.SetState(state2);
+    sut.ShouldReRender(typeof(TestState)).Should().BeFalse(); // Because the state has not changed
   }
   
-  private class TestClass:IState
+  public static void Register_RenderTrigger_With_Derived_Bool_PropertySelector()
   {
-    public string? SomeProperty { get; set; }
-    public int AnotherProperty { get; set; }
+    TestComponent sut = new();
+    TestStore store = new();
+    
+    // Use reflection to set the private Store property
+    store.SetComponentStore(sut);
+    // Make three states to test with
+    
+    TestState state0 = new() { IntProperty = 0 };
+    TestState state1 = new() { IntProperty = 0 };
+    TestState state2 = new() { IntProperty = 1 };
+    TestState state3 = new() { IntProperty = 1 };
+    
+    Expression<Func<TestState, object?>> propertySelector = t => t.DerivedBoolProperty;
+
+    // Act
+    sut.RegisterRenderTrigger(propertySelector);
+
+    // Assert
+    store.SetState(state0); // Previous state will be null
+    sut.ShouldReRender(typeof(TestState)).Should().BeTrue(); // Because PreviousState is null
+    store.SetState(state1); 
+    sut.ShouldReRender(typeof(TestState)).Should().BeFalse(); // IsActive should be the same
+    store.SetState(state2);
+    sut.ShouldReRender(typeof(TestState)).Should().BeTrue(); // IsActive should have changed
+    store.SetState(state3);
+    sut.ShouldReRender(typeof(TestState)).Should().BeFalse(); // IsActive should be the same
+  }
+  
+  // Write tests that test the following Expressions
+  // propertySelector = t => t.IntProperty;
+  // propertySelector = t => t.NullableIntProperty;
+  // propertySelector = t => t.StringProperty;
+  // propertySelector = t => t.NullableStringProperty;
+  // propertySelector = t => t.NullableReferenceProperty;
+  // propertySelector = t => t.ReferenceProperty;
+  // propertySelector = t => t.NullableReferenceProperty.
+  
+  
+  // Test setup code below
+  private class TestState:IState
+  {
+    public string StringProperty { get; set; } = null!;
+    public string? NullableStringProperty { get; set; }
+    public int IntProperty { get; set; }
+    public int? NullableIntProperty { get; set; }
+    public string? AnotherProperty { get; set; }
+    
+    public bool DerivedBoolProperty => IntProperty > 0;
+    public TestThing? NullableReferenceProperty { get; set; }
+    public TestThing ReferenceProperty { get; set; } = null!;
+
+
     // properties below are not used by the tests
     public ISender Sender { get; set; } = null!;
     public Guid Guid { get; } = Guid.Empty; 
     public void Initialize() => throw new NotImplementedException();
   }
+
+  private class TestThing
+  {
+    public string? NullableStringProperty { get; set; }
+    public string? AnotherProperty { get; set; }
+    public string StringProperty { get; set; } = null!;
+    public int? NullableIntProperty { get; set; }
+    public int IntProperty { get; set; }
+  }
 }
 
+[NotTest]
 public class TestComponent : TimeWarpStateComponent
 {
   public new void RegisterRenderTrigger<T>(Expression<Func<T, object?>> propertySelector) where T : class
@@ -55,6 +111,7 @@ public class TestComponent : TimeWarpStateComponent
   }
 }
 
+[NotTest]
 public class TestStore : IStore
 {
   private IState State { get; set; } = null!;
@@ -68,6 +125,12 @@ public class TestStore : IStore
     State = newState;
   }
   public TState? GetPreviousState<TState>() => (TState?)PreviousState;
+  
+  public void SetComponentStore(TimeWarpStateComponent component)
+  {
+    PropertyInfo? storeProperty = typeof(TimeWarpStateComponent).GetProperty("Store", BindingFlags.NonPublic | BindingFlags.Instance);
+    storeProperty?.SetValue(component, this);
+  }
   
   // Properties below are not used by the tests
   public Guid Guid { get; } = Guid.Empty;

--- a/Tests/TimeWarp.State.Tests/TimeWarpStateComponent/RegisterRenderTriggerTests.cs
+++ b/Tests/TimeWarp.State.Tests/TimeWarpStateComponent/RegisterRenderTriggerTests.cs
@@ -74,7 +74,8 @@ public class Should_
   }
   
   
-  // Write tests that test the following Expressions
+  // Aider: Write test cases that test the following Expressions name them following the above examples.
+
   // propertySelector = t => t.IntProperty;
   // propertySelector = t => t.NullableIntProperty;
   // propertySelector = t => t.StringProperty;

--- a/Tests/TimeWarp.State.Tests/TimeWarpStateComponent/RegisterRenderTriggerTests.cs
+++ b/Tests/TimeWarp.State.Tests/TimeWarpStateComponent/RegisterRenderTriggerTests.cs
@@ -15,6 +15,30 @@ public class Should_
       .Should().Throw<ArgumentNullException>();
   }
 
+  public static void Register_RenderTrigger_With_StringProperty_PropertySelector()
+  {
+    TestComponent sut = new();
+    TestStore store = new();
+    
+    store.SetComponentStore(sut);
+    
+    TestState state0 = new() { StringProperty = "Initial" };
+    TestState state1 = new() { StringProperty = "Changed" };
+    TestState state2 = new() { StringProperty = "Changed", AnotherProperty = "Changed" };
+    
+    store.SetState(state0);
+    Expression<Func<TestState, object?>> propertySelector = t => t.StringProperty;
+
+    sut.RegisterRenderTrigger(propertySelector);
+
+    sut.Should().NotBeNull();
+    sut.ShouldReRender(typeof(TestState)).Should().BeTrue();
+    store.SetState(state1);
+    sut.ShouldReRender(typeof(TestState)).Should().BeTrue();
+    store.SetState(state2);
+    sut.ShouldReRender(typeof(TestState)).Should().BeFalse();
+  }
+
   public static void Register_RenderTrigger_With_NullableString_PropertySelector()
   {
     TestComponent sut = new();
@@ -42,37 +66,6 @@ public class Should_
     store.SetState(state2);
     sut.ShouldReRender(typeof(TestState)).Should().BeFalse(); // Because the state has not changed
   }
-  
-  public static void Register_RenderTrigger_With_Derived_Bool_PropertySelector()
-  {
-    TestComponent sut = new();
-    TestStore store = new();
-    
-    // Use reflection to set the private Store property
-    store.SetComponentStore(sut);
-    // Make three states to test with
-    
-    TestState state0 = new() { IntProperty = 0 };
-    TestState state1 = new() { IntProperty = 0 };
-    TestState state2 = new() { IntProperty = 1 };
-    TestState state3 = new() { IntProperty = 1 };
-    
-    Expression<Func<TestState, object?>> propertySelector = t => t.DerivedBoolProperty;
-
-    // Act
-    sut.RegisterRenderTrigger(propertySelector);
-
-    // Assert
-    store.SetState(state0); // Previous state will be null
-    sut.ShouldReRender(typeof(TestState)).Should().BeTrue(); // Because PreviousState is null
-    store.SetState(state1); 
-    sut.ShouldReRender(typeof(TestState)).Should().BeFalse(); // IsActive should be the same
-    store.SetState(state2);
-    sut.ShouldReRender(typeof(TestState)).Should().BeTrue(); // IsActive should have changed
-    store.SetState(state3);
-    sut.ShouldReRender(typeof(TestState)).Should().BeFalse(); // IsActive should be the same
-  }
-  
   
   public static void Register_RenderTrigger_With_IntProperty_PropertySelector()
   {
@@ -122,30 +115,36 @@ public class Should_
     sut.ShouldReRender(typeof(TestState)).Should().BeFalse();
   }
 
-  public static void Register_RenderTrigger_With_StringProperty_PropertySelector()
+  public static void Register_RenderTrigger_With_Derived_Bool_PropertySelector()
   {
     TestComponent sut = new();
     TestStore store = new();
     
+    // Use reflection to set the private Store property
     store.SetComponentStore(sut);
+    // Make three states to test with
     
-    TestState state0 = new() { StringProperty = "Initial" };
-    TestState state1 = new() { StringProperty = "Changed" };
-    TestState state2 = new() { StringProperty = "Changed", AnotherProperty = "Changed" };
+    TestState state0 = new() { IntProperty = 0 };
+    TestState state1 = new() { IntProperty = 0 };
+    TestState state2 = new() { IntProperty = 1 };
+    TestState state3 = new() { IntProperty = 1 };
     
-    store.SetState(state0);
-    Expression<Func<TestState, object?>> propertySelector = t => t.StringProperty;
+    Expression<Func<TestState, object?>> propertySelector = t => t.DerivedBoolProperty;
 
+    // Act
     sut.RegisterRenderTrigger(propertySelector);
 
-    sut.Should().NotBeNull();
-    sut.ShouldReRender(typeof(TestState)).Should().BeTrue();
-    store.SetState(state1);
-    sut.ShouldReRender(typeof(TestState)).Should().BeTrue();
+    // Assert
+    store.SetState(state0); // Previous state will be null
+    sut.ShouldReRender(typeof(TestState)).Should().BeTrue(); // Because PreviousState is null
+    store.SetState(state1); 
+    sut.ShouldReRender(typeof(TestState)).Should().BeFalse(); // IsActive should be the same
     store.SetState(state2);
-    sut.ShouldReRender(typeof(TestState)).Should().BeFalse();
+    sut.ShouldReRender(typeof(TestState)).Should().BeTrue(); // IsActive should have changed
+    store.SetState(state3);
+    sut.ShouldReRender(typeof(TestState)).Should().BeFalse(); // IsActive should be the same
   }
-
+  
   public static void Register_RenderTrigger_With_NullableReferenceProperty_PropertySelector()
   {
     TestComponent sut = new();

--- a/Tests/TimeWarp.State.Tests/TimeWarpStateComponent/RegisterRenderTriggerTests.cs
+++ b/Tests/TimeWarp.State.Tests/TimeWarpStateComponent/RegisterRenderTriggerTests.cs
@@ -4,6 +4,17 @@ using TimeWarp.Fixie;
 
 public class Should_ 
 {
+  public static void RegisterRenderTrigger_NullPropertySelector_ThrowsArgumentNullException()
+  {
+    // Arrange
+    TestComponent sut = new();
+    Expression<Func<object, object?>> propertySelector = null!;
+
+    // Act and Assert
+    sut.Invoking(c => c.RegisterRenderTrigger(propertySelector))
+      .Should().Throw<ArgumentNullException>();
+  }
+
   public static void Register_RenderTrigger_With_NullableString_PropertySelector()
   {
     TestComponent sut = new();
@@ -61,6 +72,7 @@ public class Should_
     store.SetState(state3);
     sut.ShouldReRender(typeof(TestState)).Should().BeFalse(); // IsActive should be the same
   }
+  
   
   // Write tests that test the following Expressions
   // propertySelector = t => t.IntProperty;

--- a/Tests/TimeWarp.State.Tests/TimeWarpStateComponent/RegisterRenderTriggerTests.cs
+++ b/Tests/TimeWarp.State.Tests/TimeWarpStateComponent/RegisterRenderTriggerTests.cs
@@ -74,17 +74,150 @@ public class Should_
   }
   
   
-  // Aider: Write test cases that test the following Expressions name them following the above examples.
+  public static void Register_RenderTrigger_With_IntProperty_PropertySelector()
+  {
+    TestComponent sut = new();
+    TestStore store = new();
+    
+    store.SetComponentStore(sut);
+    
+    TestState state0 = new() { IntProperty = 0 };
+    TestState state1 = new() { IntProperty = 1 };
+    TestState state2 = new() { IntProperty = 1, AnotherProperty = "Changed" };
+    
+    store.SetState(state0);
+    Expression<Func<TestState, object?>> propertySelector = t => t.IntProperty;
 
-  // propertySelector = t => t.IntProperty;
-  // propertySelector = t => t.NullableIntProperty;
-  // propertySelector = t => t.StringProperty;
-  // propertySelector = t => t.NullableStringProperty;
-  // propertySelector = t => t.NullableReferenceProperty;
-  // propertySelector = t => t.ReferenceProperty;
-  // propertySelector = t => t.NullableReferenceProperty.
-  
-  
+    sut.RegisterRenderTrigger(propertySelector);
+
+    sut.Should().NotBeNull();
+    sut.ShouldReRender(typeof(TestState)).Should().BeTrue();
+    store.SetState(state1);
+    sut.ShouldReRender(typeof(TestState)).Should().BeTrue();
+    store.SetState(state2);
+    sut.ShouldReRender(typeof(TestState)).Should().BeFalse();
+  }
+
+  public static void Register_RenderTrigger_With_NullableIntProperty_PropertySelector()
+  {
+    TestComponent sut = new();
+    TestStore store = new();
+    
+    store.SetComponentStore(sut);
+    
+    TestState state0 = new() { NullableIntProperty = null };
+    TestState state1 = new() { NullableIntProperty = 1 };
+    TestState state2 = new() { NullableIntProperty = 1, AnotherProperty = "Changed" };
+    
+    store.SetState(state0);
+    Expression<Func<TestState, object?>> propertySelector = t => t.NullableIntProperty;
+
+    sut.RegisterRenderTrigger(propertySelector);
+
+    sut.Should().NotBeNull();
+    sut.ShouldReRender(typeof(TestState)).Should().BeTrue();
+    store.SetState(state1);
+    sut.ShouldReRender(typeof(TestState)).Should().BeTrue();
+    store.SetState(state2);
+    sut.ShouldReRender(typeof(TestState)).Should().BeFalse();
+  }
+
+  public static void Register_RenderTrigger_With_StringProperty_PropertySelector()
+  {
+    TestComponent sut = new();
+    TestStore store = new();
+    
+    store.SetComponentStore(sut);
+    
+    TestState state0 = new() { StringProperty = "Initial" };
+    TestState state1 = new() { StringProperty = "Changed" };
+    TestState state2 = new() { StringProperty = "Changed", AnotherProperty = "Changed" };
+    
+    store.SetState(state0);
+    Expression<Func<TestState, object?>> propertySelector = t => t.StringProperty;
+
+    sut.RegisterRenderTrigger(propertySelector);
+
+    sut.Should().NotBeNull();
+    sut.ShouldReRender(typeof(TestState)).Should().BeTrue();
+    store.SetState(state1);
+    sut.ShouldReRender(typeof(TestState)).Should().BeTrue();
+    store.SetState(state2);
+    sut.ShouldReRender(typeof(TestState)).Should().BeFalse();
+  }
+
+  public static void Register_RenderTrigger_With_NullableReferenceProperty_PropertySelector()
+  {
+    TestComponent sut = new();
+    TestStore store = new();
+    
+    store.SetComponentStore(sut);
+    
+    TestState state0 = new() { NullableReferenceProperty = null };
+    TestState state1 = new() { NullableReferenceProperty = new TestThing() };
+    TestState state2 = new() { NullableReferenceProperty = state1.NullableReferenceProperty, AnotherProperty = "Changed" };
+    
+    store.SetState(state0);
+    Expression<Func<TestState, object?>> propertySelector = t => t.NullableReferenceProperty;
+
+    sut.RegisterRenderTrigger(propertySelector);
+
+    sut.Should().NotBeNull();
+    sut.ShouldReRender(typeof(TestState)).Should().BeTrue();
+    store.SetState(state1);
+    sut.ShouldReRender(typeof(TestState)).Should().BeTrue();
+    store.SetState(state2);
+    sut.ShouldReRender(typeof(TestState)).Should().BeFalse();
+  }
+
+  public static void Register_RenderTrigger_With_ReferenceProperty_PropertySelector()
+  {
+    TestComponent sut = new();
+    TestStore store = new();
+    
+    store.SetComponentStore(sut);
+    
+    TestState state0 = new() { ReferenceProperty = new TestThing() };
+    TestState state1 = new() { ReferenceProperty = new TestThing() };
+    TestState state2 = new() { ReferenceProperty = state1.ReferenceProperty, AnotherProperty = "Changed" };
+    
+    store.SetState(state0);
+    Expression<Func<TestState, object?>> propertySelector = t => t.ReferenceProperty;
+
+    sut.RegisterRenderTrigger(propertySelector);
+
+    sut.Should().NotBeNull();
+    sut.ShouldReRender(typeof(TestState)).Should().BeTrue();
+    store.SetState(state1);
+    sut.ShouldReRender(typeof(TestState)).Should().BeTrue();
+    store.SetState(state2);
+    sut.ShouldReRender(typeof(TestState)).Should().BeFalse();
+  }
+
+  public static void Register_RenderTrigger_With_NullableReferenceProperty_NestedProperty_PropertySelector()
+  {
+    TestComponent sut = new();
+    TestStore store = new();
+    
+    store.SetComponentStore(sut);
+    
+    TestState state0 = new() { NullableReferenceProperty = new TestThing { NullableStringProperty = "Initial" } };
+    TestState state1 = new() { NullableReferenceProperty = new TestThing { NullableStringProperty = "Changed" } };
+    TestState state2 = new() { NullableReferenceProperty = state1.NullableReferenceProperty, AnotherProperty = "Changed" };
+    
+    store.SetState(state0);
+    Expression<Func<TestState, object?>> propertySelector = t => t.NullableReferenceProperty!.NullableStringProperty;
+
+    sut.RegisterRenderTrigger(propertySelector);
+
+    sut.Should().NotBeNull();
+    sut.ShouldReRender(typeof(TestState)).Should().BeTrue();
+    store.SetState(state1);
+    sut.ShouldReRender(typeof(TestState)).Should().BeTrue();
+    store.SetState(state2);
+    sut.ShouldReRender(typeof(TestState)).Should().BeFalse();
+  }
+
   // Test setup code below
   private class TestState:IState
   {

--- a/Tests/TimeWarp.State.Tests/TypeExtensionsTests.cs
+++ b/Tests/TimeWarp.State.Tests/TypeExtensionsTests.cs
@@ -1,6 +1,5 @@
 namespace GetEnclosingStateType_;
 
-using FluentAssertions;
 using MediatR;
 using TimeWarp.Features.RenderSubscriptions;
 using TimeWarp.State;

--- a/Tests/TimeWarp.State.Tests/TypeExtensionsTests.cs
+++ b/Tests/TimeWarp.State.Tests/TypeExtensionsTests.cs
@@ -1,8 +1,6 @@
 namespace GetEnclosingStateType_;
 
-using MediatR;
 using TimeWarp.Features.RenderSubscriptions;
-using TimeWarp.State;
 using TimeWarp.State.Extensions;
 
 public class TypeExtensionsTests


### PR DESCRIPTION
Add Test cases. And split TimeWarpStateComponent into partials.