### PR TITLE
If you don't supply a RenderTrigger for a state you are subscribed to

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Set common properties regarding assembly information and nuget packages -->
   <PropertyGroup>
-    <TimeWarpStateVersion>11.0.0-beta.72+8.0.303</TimeWarpStateVersion>
+    <TimeWarpStateVersion>11.0.0-beta.73+8.0.303</TimeWarpStateVersion>
     <Authors>Steven T. Cramer</Authors>
     <Product>TimeWarp State</Product>
     <PackageVersion>$(TimeWarpStateVersion)</PackageVersion>

--- a/Source/TimeWarp.State/Components/TimeWarpStateComponent.RegisterRenderTrigger.cs
+++ b/Source/TimeWarp.State/Components/TimeWarpStateComponent.RegisterRenderTrigger.cs
@@ -30,9 +30,11 @@ public partial class TimeWarpStateComponent
   {
     ArgumentNullException.ThrowIfNull(stateType);
 
-    NeedsRerender = RenderTriggers.TryGetValue(stateType, out Func<bool>? check) && check();
+    NeedsRerender = !RenderTriggers.TryGetValue(stateType, out Func<bool>? check) || check();
+
     return NeedsRerender;
   }
+
 
   /// <summary>
   /// Determines whether the component should re-render based on changes in a specific state type.


### PR DESCRIPTION
then you will rerender for any change of that state type.