### PR TITLE
Fix PowerShell XML parsing in release workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -43,7 +43,7 @@ jobs:
         id: extract_version
         run: |
           [xml]$xml = Get-Content -Path "Directory.Build.props"
-          $version = $xml.Project.PropertyGroup.TimeWarpStateVersion
+          $version = $xml.SelectSingleNode("//TimeWarpStateVersion").InnerText
           echo "Extracted version (raw): '$version'"
           $version = $version.Trim()
           echo "Extracted version (trimmed): '$version'"


### PR DESCRIPTION
## Summary

Fix for the release workflow that was failing on the version extraction step.

### Issue
The PowerShell script was failing with:
```
You cannot call a method on a null-valued expression.
```

When trying to call `.Trim()` on the extracted version.

### Root Cause
`$xml.Project.PropertyGroup.TimeWarpStateVersion` was returning a collection/array instead of a single string value, likely due to multiple PropertyGroup elements in Directory.Build.props.

### Solution
Use `SelectSingleNode("//TimeWarpStateVersion").InnerText` to directly get the text content of the TimeWarpStateVersion element, avoiding the PropertyGroup collection issue.

## Test plan

- [ ] Verify the release workflow runs successfully
- [ ] Test with a new release to confirm NuGet publishing works

🤖 Generated with [Claude Code](https://claude.ai/code)