### PR TITLE
Remove separate publishing for embedded Analyzer/SourceGenerator

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -110,28 +110,5 @@ jobs:
           }
         working-directory: ${{ github.workspace }}
 
-      - name: Publish TimeWarp.State.Analyzer
-        run: |
-          cd Source/TimeWarp.State.Analyzer/bin/Release
-          if (!(Test-Path "TimeWarp.State.Analyzer.*.nupkg")) {
-            throw "NuGet package not found for TimeWarp.State.Analyzer"
-          }
-          dotnet nuget push TimeWarp.State.Analyzer.*.nupkg --skip-duplicate --source https://api.nuget.org/v3/index.json --api-key ${{secrets.PUBLISH_TO_NUGET_ORG}}
-          if ($LASTEXITCODE -ne 0) {
-            throw "Failed to publish TimeWarp.State.Analyzer"
-          }
-        working-directory: ${{ github.workspace }}
-
-      - name: Publish TimeWarp.State.SourceGenerator
-        run: |
-          cd Source/TimeWarp.State.SourceGenerator/bin/Release
-          if (!(Test-Path "TimeWarp.State.SourceGenerator.*.nupkg")) {
-            throw "NuGet package not found for TimeWarp.State.SourceGenerator"
-          }
-          dotnet nuget push TimeWarp.State.SourceGenerator.*.nupkg --skip-duplicate --source https://api.nuget.org/v3/index.json --api-key ${{secrets.PUBLISH_TO_NUGET_ORG}}
-          if ($LASTEXITCODE -ne 0) {
-            throw "Failed to publish TimeWarp.State.SourceGenerator"
-          }
-        working-directory: ${{ github.workspace }}
 
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/Claude.md
+++ b/Claude.md
@@ -53,9 +53,10 @@ dotnet build --project <ProjectPath> --configuration Release
 
 ### Core Libraries (Source/)
 - **TimeWarp.State**: Main library with base classes, Redux DevTools, JavaScript interop
+  - Embeds Analyzer and SourceGenerator as analyzers (not separate packages)
 - **TimeWarp.State.Plus**: Extended functionality with ActionTracking, Routing, Themes
-- **TimeWarp.State.Analyzer**: Roslyn analyzers for code validation
-- **TimeWarp.State.SourceGenerator**: Code generation to reduce boilerplate
+- **TimeWarp.State.Analyzer**: Roslyn analyzers (embedded in main package)
+- **TimeWarp.State.SourceGenerator**: Code generation (embedded in main package)
 - **TimeWarp.State.Policies**: NetArchTest rules for architecture validation
 
 ### Testing Strategy
@@ -143,6 +144,15 @@ Follow structured task workflow using Kanban approach:
 - Task files: `Kanban/<Status>/<TaskID>_<Description>.md`
 - Commit format: `Task: <TaskID> = <Status> <Description>`
 - Move tasks between folders as status changes
+
+## Package Structure
+
+**Published NuGet Packages:**
+- **TimeWarp.State**: Main package (includes embedded Analyzer/SourceGenerator)
+- **TimeWarp.State.Plus**: Extended features package
+- **TimeWarp.State.Policies**: Architecture testing rules
+
+**Note**: Analyzer and SourceGenerator projects are **NOT** published as separate packages - they are embedded in the main TimeWarp.State package as analyzers.
 
 ## Essential Dependencies
 


### PR DESCRIPTION
## Summary

Fix the release workflow by removing separate NuGet publishing for Analyzer and SourceGenerator projects that are actually embedded in the main TimeWarp.State package.

### Issue
The release workflow was trying to publish TimeWarp.State.Analyzer and TimeWarp.State.SourceGenerator as separate NuGet packages, but these don't generate packages because they're embedded as analyzers in the main package.

### Root Cause
Looking at TimeWarp.State.csproj, these projects are included as embedded analyzers:
```xml
<None Include="..\TimeWarp.State.Analyzer\bin\$(Configuration)\netstandard2.0\TimeWarp.State.Analyzer.dll" Pack="true" PackagePath="analyzers\dotnet\cs"/>
<None Include="..\TimeWarp.State.SourceGenerator\bin\$(Configuration)\netstandard2.0\TimeWarp.State.SourceGenerator.dll" Pack="true" PackagePath="analyzers\dotnet\cs"/>
```

### Solution
- Removed publishing steps for Analyzer and SourceGenerator from release workflow
- Updated Claude.md to document the package structure clearly
- Only publish the actual NuGet packages: TimeWarp.State, TimeWarp.State.Plus, TimeWarp.State.Policies

## Test plan

- [ ] Manually trigger release workflow - should complete without looking for non-existent packages
- [ ] Verify only 3 packages are published to NuGet.org

🤖 Generated with [Claude Code](https://claude.ai/code)