### PR TITLE
Bump version to 11.0.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Set common properties regarding assembly information and nuget packages -->
   <PropertyGroup>
-    <TimeWarpStateVersion>11.0.1</TimeWarpStateVersion>
+    <TimeWarpStateVersion>11.0.2</TimeWarpStateVersion>
     <Authors>Steven T. Cramer</Authors>
     <Product>TimeWarp State</Product>
     <PackageVersion>$(TimeWarpStateVersion)</PackageVersion>


### PR DESCRIPTION
## Summary

Bump version to 11.0.2 for testing the fixed release workflow.

Since 11.0.1 was already used for the previous (failed) release attempt, we need to increment to 11.0.2 to test the corrected workflow that only publishes the 3 actual NuGet packages.

## Test plan

- [ ] Merge to master
- [ ] Create GitHub Release 11.0.2 
- [ ] Verify release workflow publishes only: TimeWarp.State, TimeWarp.State.Plus, TimeWarp.State.Policies

🤖 Generated with [Claude Code](https://claude.ai/code)