### PR TITLE
Fix release workflow to handle 'v' prefix in tags

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -60,8 +60,14 @@ jobs:
           
           # Only validate tag match for actual release events, not manual dispatch
           if ("${{ github.event_name }}" -eq "release") {
-            if ($releaseVersion -ne $tagName) {
-              throw "Release version ($releaseVersion) does not match tag name ($tagName)"
+            # Strip 'v' prefix from tag name if present for comparison
+            $tagNameForComparison = $tagName
+            if ($tagName.StartsWith("v")) {
+              $tagNameForComparison = $tagName.Substring(1)
+            }
+            
+            if ($releaseVersion -ne $tagNameForComparison) {
+              throw "Release version ($releaseVersion) does not match tag name ($tagName - stripped: $tagNameForComparison)"
             }
             echo "✅ Release version matches tag name"
           } else {


### PR DESCRIPTION
## Summary
- Fixed release workflow to strip 'v' prefix from tag names before validation
- Allows tags like v12.0.0-beta.1 to work properly
- Follows same pattern as timewarp-nuru workflow

## Context
The v12.0.0-beta.1 release failed because the workflow was comparing the tag name (with 'v' prefix) directly to the version number (without prefix).

🤖 Generated with [Claude Code](https://claude.ai/code)