### PR TITLE
Fix release-job gating for probe mode

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -146,7 +146,7 @@ jobs:
 
   # Release publishing job
   release:
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'release' && inputs.confirm == 'release') || (github.event_name == 'workflow_dispatch' && inputs.mode == 'probe')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -179,6 +179,7 @@ jobs:
           dotnet-version: '8.0.403'
 
       - name: Extract version from source/Directory.Build.props
+        if: github.event_name != 'workflow_dispatch' || inputs.mode != 'probe'
         id: extract_version
         run: |
           [xml]$xml = Get-Content -Path "source/Directory.Build.props"
@@ -188,6 +189,7 @@ jobs:
         shell: pwsh
 
       - name: Validate release version matches tag
+        if: github.event_name != 'workflow_dispatch' || inputs.mode != 'probe'
         if: github.event_name == 'release'
         run: |
           $releaseVersion = "${{ steps.extract_version.outputs.version }}"
@@ -204,6 +206,7 @@ jobs:
         shell: pwsh
 
       - name: Create NuGet packages
+        if: github.event_name != 'workflow_dispatch' || inputs.mode != 'probe'
         run: dotnet run --project ./scripts/package.cs
         working-directory: ${{ github.workspace }}
 
@@ -214,7 +217,12 @@ jobs:
         with:
           user: TimeWarp.Enterprises
 
+      - name: Trusted publishing probe result
+        if: github.event_name == 'workflow_dispatch' && inputs.mode == 'probe'
+        run: echo "Trusted publishing OK — OIDC exchange succeeded for this repo + workflow.yml."
+
       - name: Publish TimeWarp.State to NuGet
+        if: github.event_name != 'workflow_dispatch' || inputs.mode != 'probe'
         if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'release' && inputs.confirm == 'release')
         run: |
           $packagePath = "./artifacts/packages/TimeWarp.State.*.nupkg"
@@ -225,6 +233,7 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       - name: Publish TimeWarp.State.Plus to NuGet
+        if: github.event_name != 'workflow_dispatch' || inputs.mode != 'probe'
         if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'release' && inputs.confirm == 'release')
         run: |
           $packagePath = "./artifacts/packages/TimeWarp.State.Plus.*.nupkg"
@@ -235,6 +244,7 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       - name: Publish TimeWarp.State.Policies to NuGet
+        if: github.event_name != 'workflow_dispatch' || inputs.mode != 'probe'
         if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'release' && inputs.confirm == 'release')
         run: |
           $packagePath = "./artifacts/packages/TimeWarp.State.Policies.*.nupkg"


### PR DESCRIPTION
Follow-up to #572: release job no longer runs on bare dispatch; probe mode exercises only the OIDC login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)